### PR TITLE
Add URL base path to config

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -3,6 +3,7 @@ import starlight from '@astrojs/starlight';
 
 // https://astro.build/config
 export default defineConfig({
+	base: "/ups",
 	integrations: [
 		starlight({
 			title: 'My Docs',


### PR DESCRIPTION
Static content doesn't load because it's at the wrong path.