### PR TITLE
ci: add permissions to workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -8,6 +8,10 @@ on:
       - "docs/**"
       - ".github/workflows/publish.yaml"
 
+permissions:
+  contents: read
+  packages: read
+
 jobs:
   build-and-publish:
     uses: tailstory-wiki/builder/.github/workflows/build.yaml@main


### PR DESCRIPTION
Potential fix for [https://github.com/tailstory-wiki/ups-worldship/security/code-scanning/2](https://github.com/tailstory-wiki/ups-worldship/security/code-scanning/2)

Add an explicit `permissions` section to `.github/workflows/publish.yaml` so the workflow does not inherit potentially broad default `GITHUB_TOKEN` access.

Best fix (without changing behavior): add workflow-level minimal read permissions directly under `on` and before `jobs`:

- `contents: read`
- `packages: read`

This is the standard minimal baseline for many documentation/build publish flows and satisfies CodeQL’s requirement that permissions be explicitly constrained.  
Only `.github/workflows/publish.yaml` needs editing; no imports, methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
