### PR TITLE
Convert index to a landing page and add product links

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,1 +1,7 @@
-# Hi!
+---
+layout: landing.njk
+title: UPS WorldShip
+description: UPS shipping software for printing labels and scheduling pickups.
+---
+
+Notes on running UPS WorldShip.

--- a/docs/links.yaml
+++ b/docs/links.yaml
@@ -1,0 +1,5 @@
+links:
+  - title: UPS
+    href: https://www.ups.com
+  - title: GitHub
+    href: https://github.com/tailstory-wiki/ups-worldship


### PR DESCRIPTION
Converts the product home to the wiki's new hub layout (the no-sections case: cards point straight at pages).

## Changes

- `docs/index.md` — replaces the `# Hi!` placeholder with the new `landing.njk` layout; the Troubleshooting page shows up as a card using its existing `description` frontmatter.
- `docs/links.yaml` — **new**: external links (UPS, GitHub) for the wiki's product subnav.

## Merge order

Merge **after** tailstory-wiki/builder#13 — `layout: landing.njk` doesn't exist until the builder PR lands, so this repo's publish CI fails if merged first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015wXiRNBpbkQY8sT39PEYo9

---
_Generated by [Claude Code](https://claude.ai/code/session_015wXiRNBpbkQY8sT39PEYo9)_